### PR TITLE
ci: run npm test on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow for pull requests and pushes to main
- run the Node test suite on Node 20.x and 22.x

## Why
Pluribus is starting to handle more security-sensitive context import behavior. A visible CI signal makes contributions safer and lowers friction for outside users/contributors.

## Checks
- npm test: 21/21 passing
- git diff --check: clean